### PR TITLE
Avoid deprecation warning with IPython 4.x

### DIFF
--- a/src/boost/python/ipython/ipython_10_00/ipython_10_00.py
+++ b/src/boost/python/ipython/ipython_10_00/ipython_10_00.py
@@ -27,7 +27,10 @@ from IPython.core.error import UsageError
 from IPython.utils.ipstruct import Struct
 from IPython.core.page import page
 from IPython.core.interactiveshell import InteractiveShell
-from IPython.config.application import Application
+try:  # IPython 4.x
+    from traitlets.config.application import Application
+except: # IPython < 4.x
+    from IPython.config.application import Application
 from IPython.terminal.ipapp import launch_new_instance
 
 import PyTango


### PR DESCRIPTION
IPython 4.x moves  IPython.config --> traitlets.config
Avoid deprecation warnings by using traitlets.

(note: I just found this one when fixing [1] ... but there may be more deprecated usages)

[1] https://sourceforge.net/p/sardana/tickets/449/