### PR TITLE
Rename itango script to itango3 for python3

### DIFF
--- a/scripts/itango3
+++ b/scripts/itango3
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# ------------------------------------------------------------------------------
+# This file is part of PyTango (http://www.tinyurl.com/PyTango)
+#
+# Copyright 2006-2012 CELLS / ALBA Synchrotron, Bellaterra, Spain
+# Copyright 2013-2014 European Synchrotron Radiation Facility, Grenoble, France
+#
+# Distributed under the terms of the GNU Lesser General Public License,
+# either version 3 of the License, or (at your option) any later version.
+# See LICENSE.txt for more info.
+# ------------------------------------------------------------------------------
+
+"""The itango startup file. This executable is actually an extension of the 
+   ipython file that can be found in <prefix>/ipython (prefix usually being in 
+   linux '/usr/bin'"""
+
+__all__ = [ "main" ]
+
+__docformat__ = 'restructuredtext'
+    
+def main():
+    import PyTango.ipython
+    PyTango.ipython.run()
+    
+if __name__ == '__main__':
+    main()

--- a/scripts/itango3
+++ b/scripts/itango3
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ------------------------------------------------------------------------------
 # This file is part of PyTango (http://www.tinyurl.com/PyTango)
@@ -11,17 +11,17 @@
 # See LICENSE.txt for more info.
 # ------------------------------------------------------------------------------
 
-"""The itango startup file. This executable is actually an extension of the 
-   ipython file that can be found in <prefix>/ipython (prefix usually being in 
+"""The itango startup file. This executable is actually an extension of the
+   ipython file that can be found in <prefix>/ipython (prefix usually being in
    linux '/usr/bin'"""
 
 __all__ = [ "main" ]
 
 __docformat__ = 'restructuredtext'
-    
+
 def main():
     import PyTango.ipython
     PyTango.ipython.run()
-    
+
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -121,31 +121,10 @@ def has_numpy(with_src=True):
 
 
 def get_script_files():
-
-    FILTER_OUT = []  # "winpostinstall.py",
-
-    if os.name != "nt":
-        FILTER_OUT.append("pytango_winpostinstall.py")
-
-    scripts_dir = abspath("scripts")
-    scripts = []
-    items = os.listdir(scripts_dir)
-    for item in items:
-        # avoid hidden files
-        if item.startswith("."):
-            continue
-        abs_item = os.path.join(scripts_dir, item)
-        # avoid non files
-        if not os.path.isfile(abs_item):
-            continue
-        if item.endswith('c') and item[:-1] in items:
-            continue
-        # avoid any core dump... of course there isn't any :-) but just in case
-        if item.startswith('core'):
-            continue
-        if item in FILTER_OUT:
-            continue
-        scripts.append('scripts/' + item)
+    major = platform.python_version_tuple()[0]
+    scripts = ['scripts/itango3' if major == 3 else 'scripts/itango']
+    if os.name == "nt":
+        scripts.append("scripts/pytango_winpostinstall.py")
     return scripts
 
 
@@ -171,7 +150,7 @@ def add_lib(name, dirs, sys_libs, env_name=None, lib_name=None, inc_suffix=None)
             if os.path.isdir(lib64_dir):
                 lib_dirs.insert(0, lib64_dir)
         dirs['library_dirs'].extend(lib_dirs)
-        
+
         if lib_name.startswith('lib'):
             lib_name = lib_name[3:]
         dirs['libraries'].append(lib_name)

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ def has_numpy(with_src=True):
 
 
 def get_script_files():
-    major = platform.python_version_tuple()[0]
+    major = int(platform.python_version_tuple()[0])
     scripts = ['scripts/itango3' if major == 3 else 'scripts/itango']
     if os.name == "nt":
         scripts.append("scripts/pytango_winpostinstall.py")

--- a/setup.py
+++ b/setup.py
@@ -343,6 +343,9 @@ def setup_args():
                 boost_library_name += pyver
             elif 'gentoo' in dist_name:
                 boost_library_name += "-" + ".".join(map(str, py_ver[:2]))
+            elif 'fedora' in dist_name or 'centos' in dist_name:
+                if int(py_ver[0]) == 3:
+                    boost_library_name += '3'
     else:
         inc_dir = os.path.join(BOOST_ROOT, 'include')
         lib_dirs = [os.path.join(BOOST_ROOT, 'lib')]


### PR DESCRIPTION
This PR should solve the file conflicts when installing both python 2 and python 3 version of PyTango.

It adds a bit of code duplication but it should be removed later on anyway by using entry points instead of scripts. Another issue is that it might not be obvious that `itango3` refers to python 3 and not tango 3.

This PR also updates the boost library name for python3 on Fedora and CentOS.

Still not completely tested, will confirm soon.