### PR TITLE
Fix auto tango monitor

### DIFF
--- a/src/boost/cpp/server/auto_monitor.cpp
+++ b/src/boost/cpp/server/auto_monitor.cpp
@@ -23,30 +23,31 @@ class AutoTangoMonitor
   Tango::DeviceClass                *klass;
 
 public:
-  AutoTangoMonitor(Tango::DeviceImpl *di)
+  AutoTangoMonitor(Tango::DeviceImpl *dev_arg) : mon(), dev(), klass()
   {
-    dev = di;
+    dev = dev_arg;
   }
 
-  AutoTangoMonitor(Tango::DeviceClass *dc)
+  AutoTangoMonitor(Tango::DeviceClass *klass_arg) : mon(), dev(), klass()
   {
-    klass = dc;
+    klass = klass_arg;
   }
 
   void acquire()
   {
-    if (mon == NULL)
+    if (mon != NULL)
     {
-      if (dev != NULL)
-      {
-	AutoPythonAllowThreads no_gil;
-        mon = new Tango::AutoTangoMonitor(dev);
-      }
-      else if (klass != NULL)
-      {
-	AutoPythonAllowThreads no_gil;
-        mon = new Tango::AutoTangoMonitor(klass);
-      }
+      return;
+    }
+    if (dev != NULL)
+    {
+      AutoPythonAllowThreads no_gil;
+      mon = new Tango::AutoTangoMonitor(dev);
+    }
+    else if (klass != NULL)
+    {
+      AutoPythonAllowThreads no_gil;
+      mon = new Tango::AutoTangoMonitor(klass);
     }
   }
 

--- a/src/boost/cpp/server/auto_monitor.cpp
+++ b/src/boost/cpp/server/auto_monitor.cpp
@@ -23,14 +23,14 @@ class AutoTangoMonitor
   Tango::DeviceClass                *klass;
 
 public:
-  AutoTangoMonitor(Tango::DeviceImpl *dev)
+  AutoTangoMonitor(Tango::DeviceImpl *di)
   {
-    this.dev = dev;
+    dev = di;
   }
 
-  AutoTangoMonitor(Tango::DeviceClass *klass)
+  AutoTangoMonitor(Tango::DeviceClass *dc)
   {
-    this.klass = klass;
+    klass = dc;
   }
 
   void acquire()
@@ -55,6 +55,7 @@ public:
     if (mon != NULL)
     {
       delete mon;
+      mon = NULL;
     }
   }
 

--- a/src/boost/python/auto_monitor.py
+++ b/src/boost/python/auto_monitor.py
@@ -17,13 +17,13 @@ __all__ = ["auto_monitor_init"]
 
 __docformat__ = "restructuredtext"
 
-import copy
-
-from .utils import document_method as __document_method
 from ._PyTango import AutoTangoMonitor, AutoTangoAllowThreads
 
+
 def __AutoTangoMonitor__enter__(self):
+    self._acquire
     return self
+
 
 def __AutoTangoMonitor__exit__(self, *args, **kwargs):
     self._release()
@@ -33,9 +33,10 @@ def __init_AutoTangoMonitor():
     AutoTangoMonitor.__enter__ = __AutoTangoMonitor__enter__
     AutoTangoMonitor.__exit__ = __AutoTangoMonitor__exit__
 
+
 def __doc_AutoTangoMonitor():
     AutoTangoMonitor.__doc__ = """\
-    
+
     In a tango server, guard the tango monitor within a python context::
 
         with AutoTangoMonitor(dev):
@@ -43,8 +44,10 @@ def __doc_AutoTangoMonitor():
             do something
     """
 
+
 def __AutoTangoAllowThreads__enter__(self):
     return self
+
 
 def __AutoTangoAllowThreads__exit__(self, *args, **kwargs):
     self._acquire()
@@ -54,15 +57,17 @@ def __init_AutoTangoAllowThreads():
     AutoTangoAllowThreads.__enter__ = __AutoTangoAllowThreads__enter__
     AutoTangoAllowThreads.__exit__ = __AutoTangoAllowThreads__exit__
 
+
 def __doc_AutoTangoAllowThreads():
     AutoTangoAllowThreads.__doc__ = """\
-    
+
     In a tango server, free the tango monitor within a context:
 
         with AutoTangoAllowThreads(dev):
             # code here is not under the tango device monitor
             do something
     """
+
 
 def auto_monitor_init(doc=True):
     __init_AutoTangoMonitor()

--- a/src/boost/python/auto_monitor.py
+++ b/src/boost/python/auto_monitor.py
@@ -21,7 +21,7 @@ from ._PyTango import AutoTangoMonitor, AutoTangoAllowThreads
 
 
 def __AutoTangoMonitor__enter__(self):
-    self._acquire
+    self._acquire()
     return self
 
 


### PR DESCRIPTION
This is a fix proposal for issue #17:

- acquire lock on `__enter__` instead of constructor
- release the GIL while acquiring the lock
- safer release method

I quickly tested it with the example included in issue #17, and it seems to work fine!