### PR TITLE
setup.py: get -l flags from pkg-config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def pkg_config(*packages, **config):
         "-l": "libraries",
     }
     cmd = ["pkg-config", "--cflags-only-I",
-           "--libs-only-L", " ".join(packages)]
+           "--libs-only-L", "--libs-only-l", " ".join(packages)]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     result = proc.wait()
     result = str(proc.communicate()[0].decode("utf-8"))


### PR DESCRIPTION
The pkg-config function already handles `-l` results from pkg-config. To
get them, we need to pass `--libs-only-l` to pkg-config as well. This
fixes a build error if you try to compile the library on environments
where tango libraries is not located in the same directory as the deps
of tango (zeromq and omniorb).