### PR TITLE
Documentation update and readthedocs configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,17 +13,21 @@ import sys
 import os
 import re
 
-# tango imports
-import tango
-from tango import Release
-
-print("Building documentation for PyTango {0}".format(Release.version_long))
-print("Using PyTango from: {0}".format(os.path.dirname(tango.__file__)))
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.append(os.path.abspath('sphinxext'))
+sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath('./'))
+
+
+# Import tango
+try:
+    import tango
+except ImportError:
+    from mock_tango_extension import tango
+from tango import Release
+print("Building documentation for PyTango {0}".format(Release.version_long))
+print("Using PyTango from: {0}".format(os.path.dirname(tango.__file__)))
 
 needs_sphinx = "1.0"
 
@@ -35,12 +39,8 @@ extensions = ['sphinx.ext.pngmath',
               'sphinx.ext.autodoc',
               'sphinx.ext.doctest',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.todo']
-
-# disable until graphviz works in pyhon 3
-if sys.hexversion < 0x03000000:
-    extensions.append('sphinx.ext.graphviz')
-
+              'sphinx.ext.todo',
+              'sphinx.ext.graphviz']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -256,7 +256,7 @@ intersphinx_mapping = {
     'http://api.mongodb.org/python/current/' : None,
     'http://packages.python.org/CouchDB/' : None,
     'http://pycassa.github.com/pycassa/' : None,
-    'http://docs.sqlalchemy.org/en/rel_0_7/' : None,
+    'http://docs.sqlalchemy.org/en/latest/' : None,
 }
 
 todo_include_todos = True

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,6 @@
+name: py35
+dependencies:
+- python=3.5
+- numpy
+- gevent
+- graphviz

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -56,7 +56,9 @@ Bugs can be reported as tickets in `TANGO Source forge <https://sourceforge.net/
 When making a bug report don't forget to select *PyTango* in **Category**.
 
 It is also helpfull if you can put in the ticket description the PyTango information.
-It can be a dump of::
+It can be a dump of:
+
+.. sourcecode:: console
 
    $ python -c "from tango.utils import info; print(info())"
 
@@ -943,7 +945,7 @@ array:
     +-------------------+-----------------------------------+------------------------------------------+
     |       key         |              value                |            definition                    |
     +===================+===================================+==========================================+
-    | "display level"   | tango.DispLevel enum value      |   The attribute display level            |
+    | "display level"   | tango.DispLevel enum value        |   The attribute display level            |
     +-------------------+-----------------------------------+------------------------------------------+
     |"polling period"   |          Any number               | The attribute polling period (mS)        |
     +-------------------+-----------------------------------+------------------------------------------+

--- a/doc/mock_tango_extension.py
+++ b/doc/mock_tango_extension.py
@@ -1,0 +1,70 @@
+__all__ = ['tango']
+
+# Imports
+import sys
+from mock import MagicMock
+
+
+# Extension mock class
+class ExtensionMock(MagicMock):
+    __doc__ = None
+    __mro__ = ()
+
+    @property
+    def __name__(self):
+        return self._mock_name.split('.')[-1]
+
+    def __getattr__(self, name):
+        # Limit device class discovery
+        if name == 'Device_6Impl':
+            raise AttributeError
+        # Emulate device class inheritance
+        if name == '__base__':
+            return {
+                'Device_5Impl': _tango.Device_4Impl,
+                'Device_4Impl': _tango.Device_3Impl,
+                'Device_3Impl': _tango.Device_2Impl,
+                'Device_2Impl': _tango.DeviceImpl,
+                'DeviceImpl': object}[self.__name__]
+        # Regular mock behavior
+        return MagicMock.__getattr__(self, name)
+
+    def __setattr__(self, name, value):
+        # Ignore unsupported magic methods
+        if name in ["__init__", "__getattr__", "__setattr__"]:
+            return
+        # Hook in tango.base_types to patch document_enum
+        if name == '__getinitargs__' and self.__name__ == 'AttributeInfo':
+            import tango.base_types
+            tango.base_types.__dict__['__document_enum'] = document_enum
+        # Regular mock behavior
+        MagicMock.__setattr__(self, name, value)
+
+
+# Remove all public methods
+for name in dir(ExtensionMock):
+    if not name.startswith('_') and \
+       callable(getattr(ExtensionMock, name)):
+        setattr(ExtensionMock, name, None)
+
+
+# Patched version of document_enum
+def document_enum(klass, enum_name, desc, append=True):
+    getattr(klass, enum_name).__doc__ = desc
+
+
+# Patch the extension module
+_tango = ExtensionMock(name='_tango')
+_tango.constants.TgLibVers = "9.2.2"
+_tango._get_tango_lib_release.return_value = 922
+
+
+# Patch modules
+sys.modules['tango._tango'] = _tango
+sys.modules['tango.constants'] = _tango.constants
+print('Mocking tango._tango extension module')
+
+# Try to import
+import tango
+import tango.futures
+import tango.gevent

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: doc/environment.yml

--- a/tango/server.py
+++ b/tango/server.py
@@ -722,15 +722,15 @@ class attribute(AttrData):
     parameter              type                                       default value                                 description
     ===================== ================================ ======================================= =======================================================================================
     name                   :obj:`str`                       class member name                       alternative attribute name
-    dtype                  :obj:`object`                    :obj:`~tango.CmdArgType.DevDouble`    data type (see :ref:`Data type equivalence <pytango-hlapi-datatypes>`)
-    dformat                :obj:`~tango.AttrDataFormat`   :obj:`~tango.AttrDataFormat.SCALAR`   data format
+    dtype                  :obj:`object`                    :obj:`~tango.CmdArgType.DevDouble`      data type (see :ref:`Data type equivalence <pytango-hlapi-datatypes>`)
+    dformat                :obj:`~tango.AttrDataFormat`     :obj:`~tango.AttrDataFormat.SCALAR`     data format
     max_dim_x              :obj:`int`                       1                                       maximum size for x dimension (ignored for SCALAR format)
     max_dim_y              :obj:`int`                       0                                       maximum size for y dimension (ignored for SCALAR and SPECTRUM formats)
-    display_level          :obj:`~tango.DispLevel`        :obj:`~tango.DisLevel.OPERATOR`       display level
+    display_level          :obj:`~tango.DispLevel`          :obj:`~tango.DisLevel.OPERATOR`         display level
     polling_period         :obj:`int`                       -1                                      polling period
     memorized              :obj:`bool`                      False                                   attribute should or not be memorized
     hw_memorized           :obj:`bool`                      False                                   write method should be called at startup when restoring memorize value (dangerous!)
-    access                 :obj:`~tango.AttrWriteType`    :obj:`~tango.AttrWriteType.READ`      read only/ read write / write only access
+    access                 :obj:`~tango.AttrWriteType`      :obj:`~tango.AttrWriteType.READ`        read only/ read write / write only access
     fget (or fread)        :obj:`str` or :obj:`callable`    'read_<attr_name>'                      read method name or method object
     fset (or fwrite)       :obj:`str` or :obj:`callable`    'write_<attr_name>'                     write method name or method object
     is_allowed             :obj:`str` or :obj:`callable`    'is_<attr_name>_allowed'                is allowed method name or method object
@@ -755,9 +755,9 @@ class attribute(AttrData):
     archive_abs_change     :obj:`str`                       None
     archive_rel_change     :obj:`str`                       None
     archive_period         :obj:`str`                       None
-    green_mode             :obj:`~tango.GreenMode`        None                                    green mode for read and write. None means use server green mode.
-    read_green_mode        :obj:`~tango.GreenMode`        None                                    green mode for read. None means use server green mode.
-    write_green_mode       :obj:`~tango.GreenMode`        None                                    green mode for write. None means use server green mode.
+    green_mode             :obj:`~tango.GreenMode`          None                                    green mode for read and write. None means use server green mode.
+    read_green_mode        :obj:`~tango.GreenMode`          None                                    green mode for read. None means use server green mode.
+    write_green_mode       :obj:`~tango.GreenMode`          None                                    green mode for write. None means use server green mode.
     ===================== ================================ ======================================= =======================================================================================
 
     .. note::
@@ -919,16 +919,16 @@ class pipe(PipeData):
     parameter              type                                       default value                                 description
     ===================== ================================ ======================================= =======================================================================================
     name                   :obj:`str`                       class member name                       alternative pipe name
-    display_level          :obj:`~tango.DispLevel`        :obj:`~tango.DisLevel.OPERATOR`       display level
-    access                 :obj:`~tango.PipeWriteType`    :obj:`~tango.PipeWriteType.READ`      read only/ read write access
+    display_level          :obj:`~tango.DispLevel`          :obj:`~tango.DisLevel.OPERATOR`         display level
+    access                 :obj:`~tango.PipeWriteType`      :obj:`~tango.PipeWriteType.READ`        read only/ read write access
     fget (or fread)        :obj:`str` or :obj:`callable`    'read_<pipe_name>'                      read method name or method object
     fset (or fwrite)       :obj:`str` or :obj:`callable`    'write_<pipe_name>'                     write method name or method object
     is_allowed             :obj:`str` or :obj:`callable`    'is_<pipe_name>_allowed'                is allowed method name or method object
     label                  :obj:`str`                       '<pipe_name>'                           pipe label
     doc (or description)   :obj:`str`                       ''                                      pipe description
-    green_mode             :obj:`~tango.GreenMode`        None                                    green mode for read and write. None means use server green mode.
-    read_green_mode        :obj:`~tango.GreenMode`        None                                    green mode for read. None means use server green mode.
-    write_green_mode       :obj:`~tango.GreenMode`        None                                    green mode for write. None means use server green mode.
+    green_mode             :obj:`~tango.GreenMode`          None                                    green mode for read and write. None means use server green mode.
+    read_green_mode        :obj:`~tango.GreenMode`          None                                    green mode for read. None means use server green mode.
+    write_green_mode       :obj:`~tango.GreenMode`          None                                    green mode for write. None means use server green mode.
     ===================== ================================ ======================================= =======================================================================================
 
     The same example with a read-write ROI, a customized label and description::


### PR DESCRIPTION
This PR includes:
- Mock `tango._tango` to generate the documentation without the C++ extension
- Add a build environment for readthedocs (python 3.5 is required for the mocking to work)
- Fix documentation warnings (table formatting and sphinx configuration)
