### PR TITLE
Fix #24: dev_status and dangling pointer

### DIFF
--- a/ext/server/device_impl.cpp
+++ b/ext/server/device_impl.cpp
@@ -998,9 +998,22 @@ Tango::DevState Device_3ImplWrap::default_dev_state()
 
 Tango::ConstDevString Device_3ImplWrap::dev_status()
 {
-    CALL_DEVICE_METHOD_RET(Device_3Impl, dev_status)
-    // Keep the compiler quiet
-    return "Impossible state";
+    __AUX_DECL_CALL_DEVICE_METHOD
+    try
+    {
+        if (override dev_status = this->get_override("dev_status") )
+	{
+	    this->the_status = (const char *)dev_status();
+	}
+        else
+	{
+            this->the_status = Device_3Impl::dev_status();
+        }
+    }
+    __AUX_CATCH_PY_EXCEPTION \
+    __AUX_CATCH_EXCEPTION(dev_status)
+
+    return this->the_status.c_str();
 }
 
 Tango::ConstDevString Device_3ImplWrap::default_dev_status()
@@ -1160,9 +1173,22 @@ Tango::DevState Device_4ImplWrap::default_dev_state()
 
 Tango::ConstDevString Device_4ImplWrap::dev_status()
 {
-    CALL_DEVICE_METHOD_RET(Device_4Impl, dev_status)
-    // Keep the compiler quiet
-    return "Impossible state";
+    __AUX_DECL_CALL_DEVICE_METHOD
+    try
+    {
+        if (override dev_status = this->get_override("dev_status") )
+	{
+	    this->the_status = (const char *)dev_status();
+	}
+        else
+	{
+            this->the_status = Device_4Impl::dev_status();
+        }
+    }
+    __AUX_CATCH_PY_EXCEPTION \
+    __AUX_CATCH_EXCEPTION(dev_status)
+
+    return this->the_status.c_str();
 }
 
 Tango::ConstDevString Device_4ImplWrap::default_dev_status()
@@ -1315,9 +1341,22 @@ Tango::DevState Device_5ImplWrap::default_dev_state()
 
 Tango::ConstDevString Device_5ImplWrap::dev_status()
 {
-    CALL_DEVICE_METHOD_RET(Device_5Impl, dev_status)
-    // Keep the compiler quiet
-    return "Impossible state";
+    __AUX_DECL_CALL_DEVICE_METHOD
+    try
+    {
+        if (override dev_status = this->get_override("dev_status") )
+	{
+	  this->the_status = (const char *)dev_status();
+	}
+        else
+	{
+            this->the_status = Device_5Impl::dev_status();
+        }
+    }
+    __AUX_CATCH_PY_EXCEPTION \
+    __AUX_CATCH_EXCEPTION(dev_status)
+
+    return this->the_status.c_str();
 }
 
 Tango::ConstDevString Device_5ImplWrap::default_dev_status()

--- a/ext/server/device_impl.h
+++ b/ext/server/device_impl.h
@@ -124,6 +124,8 @@ public:
     /** a reference to itself */
     PyObject *the_self;
 
+    std::string the_status;
+
     PyDeviceImplBase(PyObject *self);
 
     virtual ~PyDeviceImplBase();


### PR DESCRIPTION
keep record of last status in internal DeviceImpl member (C++ level)