### PR TITLE
Unit-testing for the server API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 *.cfg
 MANIFEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 cache:
   directories:
     - ./miniconda  # Conda environment
-    - ./build      # pytango build
     - ./.eggs      # pytest eggs
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+
+language: python
+
+python:
+  - 2.7
+  - 3.4
+
+cache:
+  directories:
+    - .
+
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda update --yes conda
+
+install:
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION 
+  - conda install --yes -c vxgmichel tango=9.2.2
+  - conda install --yes numpy  # Not a strong requirement yet
+
+script:
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 
 language: python
 
+os: linux
+
 python:
-  - 2.7
-  - 3.4
+  - 3.5
 
 cache:
   directories:
@@ -17,7 +18,8 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION 
+  - conda create --yes --name buildenv python=$TRAVIS_PYTHON_VERSION
+  - source activate buildenv
   - conda install --yes -c vxgmichel tango=9.2.2
   - conda install --yes numpy  # Not a strong requirement yet
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ language: python
 os: linux
 
 python:
+  - 2.7
+  - 3.4
   - 3.5
-
-cache:
-  directories:
-    - .
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -20,8 +18,10 @@ before_install:
 install:
   - conda create --yes --name buildenv python=$TRAVIS_PYTHON_VERSION
   - source activate buildenv
+  - conda install --yes boost
   - conda install --yes -c vxgmichel tango=9.2.2
   - conda install --yes numpy  # Not a strong requirement yet
+  - export BOOST_ROOT=$CONDA_PREFIX TANGO_ROOT=$CONDA_PREFIX ZMQ_ROOT=$CONDA_PREFIX OMNI_ROOT=$CONDA_PREFIX
 
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
-
 language: python
-
 os: linux
 
 python:
@@ -9,19 +7,35 @@ python:
   - 3.4
   - 3.5
 
+cache:
+  directories:
+    - ./miniconda  # Conda environment
+    - ./build      # pytango build
+    - ./.eggs      # pytest eggs
+
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  # Add conda to path
+  - export PATH="$PWD/miniconda/bin:$PATH"
+  # Install miniconda if not in cache
+  - conda -V || wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - conda -V || bash miniconda.sh -b -p ./miniconda -f
+  # Update conda
   - conda update --yes conda
+  # Create build environment if it doesn't exist
+  - source activate buildenv || conda create --yes --name buildenv python=$TRAVIS_PYTHON_VERSION
+  # Activate build environment
+  - source activate buildenv
 
 install:
-  - conda create --yes --name buildenv python=$TRAVIS_PYTHON_VERSION
-  - source activate buildenv
+  # Install build dependencies
   - conda install --yes boost
   - conda install --yes -c vxgmichel tango=9.2.2
   - conda install --yes numpy  # Not a strong requirement yet
+  # Use conda prefix as root for the dependencies
   - export BOOST_ROOT=$CONDA_PREFIX TANGO_ROOT=$CONDA_PREFIX ZMQ_ROOT=$CONDA_PREFIX OMNI_ROOT=$CONDA_PREFIX
 
-script:
-  - python setup.py test
+  # Uncomment the following line if the tests are running in parrallel
+  # with pytest-xdist (see https://github.com/pytest-dev/pytest-xdist/issues/41):
+  # - pip install -U pytest pytest-xdist six mock
+
+script: python setup.py build && python setup.py test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --boxed

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --boxed
+addopts = --boxed test

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ skip_build=True
 skip_build=True
 title=PyTango 9
 bitmap=doc\logo-medium.bmp
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ POSIX = 'posix' in os.name
 WINDOWS = 'nt' in os.name
 IS64 = 8 * struct.calcsize("P") == 64
 PYTHON_VERSION = platform.python_version_tuple()
+PYTHON2 = ('2',) <= PYTHON_VERSION < ('3',)
+PYTHON3 = ('3',) <= PYTHON_VERSION < ('4',)
 
 # Linux distribution
 distribution = platform.linux_distribution()[0].lower() if POSIX else ""
@@ -52,6 +54,9 @@ distribution_match = lambda names: any(x in distribution for x in names)
 DEBIAN = distribution_match(['debian', 'ubuntu', 'mint'])
 REDHAT = distribution_match(['redhat', 'fedora', 'centos'])
 GENTOO = distribution_match(['gentoo'])
+
+# Arguments
+TESTING = any(x in sys.argv for x in ['test', 'pytest'])
 
 
 def pkg_config(*packages, **config):
@@ -353,7 +358,7 @@ def setup_args():
             suffix = "-py{v[0]}{v[1]}".format(v=PYTHON_VERSION)
             boost_library_name += suffix
         elif REDHAT:
-            if PYTHON_VERSION >= ('3',):
+            if PYTHON3:
                 boost_library_name += '3'
         elif GENTOO:
             suffix = "-{v[0]}.{v[1]}".format(v=PYTHON_VERSION)
@@ -418,11 +423,13 @@ def setup_args():
     ]
 
     setup_requires = [
-        'pytest-runner',
+        'pytest-runner' if TESTING else '',
     ]
 
     tests_require = [
         'pytest-xdist',
+        'gevent',
+        'trollius' if PYTHON2 else '',
     ]
 
     package_data = {

--- a/setup.py
+++ b/setup.py
@@ -417,6 +417,15 @@ def setup_args():
         'six',
     ]
 
+    setup_requires = [
+        'pytest-runner',
+    ]
+
+    tests_require = [
+        'pytest',
+        'pytest-xdist',
+    ]
+
     package_data = {
         'PyTango': [],
     }
@@ -523,6 +532,8 @@ def setup_args():
         keywords=Release.keywords,
         requires=requires,
         install_requires=install_requires,
+        setup_requires=setup_requires,
+        tests_require=tests_require,
         ext_package='tango',
         ext_modules=[pytango_ext],
         cmdclass=cmdclass)

--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,6 @@ def setup_args():
     ]
 
     tests_require = [
-        'pytest',
         'pytest-xdist',
     ]
 

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -75,7 +75,8 @@ class DeviceTestContext(object):
 
     nodb = "#dbase=no"
     command = "{0} {1} -ORBendPoint giop:tcp::{2} -file={3}"
-    connect_time = 6.0
+    connect_timeout = 6.0
+    disconnect_timeout = connect_timeout
 
     def __init__(self, device, device_cls=None, server_name=None,
                  instance_name=None, device_name=None, properties={},
@@ -154,7 +155,7 @@ class DeviceTestContext(object):
         self.connect()
         return self
 
-    @retry(connect_time, [ConnectionFailed, DevFailed])
+    @retry(connect_timeout, [ConnectionFailed, DevFailed])
     def connect(self):
         if not self.thread.is_alive():
             raise RuntimeError(
@@ -168,10 +169,12 @@ class DeviceTestContext(object):
         """Kill the server."""
         if self.server:
             self.server.command_inout('Kill')
-        self.thread.join(timeout)
+        self.join(timeout)
         os.unlink(self.db)
 
     def join(self, timeout=None):
+        if timeout is None:
+            timeout = self.disconnect_timeout
         self.thread.join(timeout)
 
     def __enter__(self):

--- a/tango/test_context.py
+++ b/tango/test_context.py
@@ -79,7 +79,7 @@ class DeviceTestContext(object):
 
     def __init__(self, device, device_cls=None, server_name=None,
                  instance_name=None, device_name=None, properties={},
-                 db=None, port=0, debug=5, daemon=False, process=False):
+                 db=None, port=0, debug=3, daemon=False, process=False):
         """Inititalize the context to run a given device."""
         # Argument
         tangoclass = device.__name__
@@ -156,6 +156,9 @@ class DeviceTestContext(object):
 
     @retry(connect_time, [ConnectionFailed, DevFailed])
     def connect(self):
+        if not self.thread.is_alive():
+            raise RuntimeError(
+                'The server did not start. Check stdout for more information.')
         self.device = DeviceProxy(self.get_device_access())
         self.device.ping()
         self.server = DeviceProxy(self.get_server_access())

--- a/tango/test_utils.py
+++ b/tango/test_utils.py
@@ -1,0 +1,63 @@
+"""Test utilities"""
+
+__all__ = ['DeviceTestContext', 'SimpleDevice']
+
+# Imports
+from six import add_metaclass
+
+# Local imports
+from . import utils
+from . import DevState, CmdArgType, GreenMode
+from .server import Device, DeviceMeta
+from .test_context import DeviceTestContext
+
+# Conditional imports
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+
+# Test devices
+
+@add_metaclass(DeviceMeta)
+class SimpleDevice(Device):
+    def init_device(self):
+        self.set_state(DevState.ON)
+
+
+# Pytest fixtures
+
+if pytest:
+
+    @pytest.fixture(params=DevState.values.values())
+    def state(request):
+        return request.param
+
+    @pytest.fixture(params=utils._scalar_types)
+    def typed_values(request):
+        dtype = request.param
+        # Unsupported types
+        if dtype in [CmdArgType.DevInt, CmdArgType.ConstDevString,
+                     CmdArgType.DevEncoded, CmdArgType.DevUChar]:
+            pytest.xfail('Should we support those types?')
+        # Supported types
+        if dtype in utils._scalar_str_types:
+            return dtype, ['hey hey', 'my my']
+        if dtype in utils._scalar_bool_types:
+            return dtype, [False, True]
+        if dtype in utils._scalar_int_types:
+            return dtype, [1, 2]
+        if dtype in utils._scalar_float_types:
+            return dtype, [2.71, 3.14]
+
+    @pytest.fixture(params=GreenMode.values.values())
+    def green_mode(request):
+        return request.param
+
+    @pytest.fixture(params=[
+        GreenMode.Synchronous,
+        GreenMode.Asyncio,
+        GreenMode.Gevent])
+    def server_green_mode(request):
+        return request.param

--- a/test/context.py
+++ b/test/context.py
@@ -2,6 +2,7 @@
 
 # Imports
 import platform
+import tempfile
 from socket import socket
 from functools import wraps
 from time import sleep, time
@@ -54,7 +55,7 @@ class TangoTestContext(object):
 
     def __init__(self, device, device_cls=None, server_name=None,
                  instance_name=None, device_name=None, properties={},
-                 db="tango.db", port=0, debug=0, daemon=False, process=False):
+                 db=None, port=0, debug=0, daemon=False, process=False):
         """Inititalize the context to run a given device."""
         # Argument
         tangoclass = device.__name__
@@ -66,6 +67,8 @@ class TangoTestContext(object):
             device_name = 'test/nodb/' + server_name.lower()
         if not port:
             port = get_port()
+        if db is None:
+            _, db = tempfile.mkstemp()
         # Attributes
         self.port = port
         self.device_name = device_name
@@ -73,8 +76,8 @@ class TangoTestContext(object):
         self.host = "{0}:{1}/".format(platform.node(), self.port)
         self.device = self.server = None
         # File
-        self.generate_db_file(server_name, instance_name, device_name,
-                              tangoclass, properties, db)
+        self.generate_db_file(server_name, instance_name, device_name, db,
+                              tangoclass, properties)
         # Command args
         string = self.command.format(server_name, instance_name, port, db)
         string += " -v{0}".format(debug) if debug else ""
@@ -95,8 +98,8 @@ class TangoTestContext(object):
         self.thread.daemon = daemon
 
     @staticmethod
-    def generate_db_file(server, instance, device,
-                         tangoclass=None, properties={}, db="tango.db"):
+    def generate_db_file(server, instance, device, db,
+                         tangoclass=None, properties={}):
         """Generate a database file corresponding to the given arguments."""
         if not tangoclass:
             tangoclass = server

--- a/test/context.py
+++ b/test/context.py
@@ -1,0 +1,153 @@
+"""Contain the context to run a device without a database."""
+
+# Imports
+import platform
+from socket import socket
+from functools import wraps
+from time import sleep, time
+from threading import Thread
+from multiprocessing import Process
+
+# PyTango imports
+from tango.server import run
+from tango import DeviceProxy, Database, ConnectionFailed, DevFailed
+
+
+# Retry decorator
+def retry(period, errors, pause=0.001):
+    """Retry decorator."""
+    errors = tuple(errors)
+
+    def dec(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            stop = time() + period
+            first = True
+            while first or time() < stop:
+                sleep(pause)
+                try:
+                    return func(*args, **kwargs)
+                except errors as e:
+                    first = False
+            raise e
+        return wrapper
+    return dec
+
+
+# Get available port
+def get_port():
+    sock = socket()
+    sock.bind(('', 0))
+    res = sock.getsockname()[1]
+    del sock
+    return res
+
+
+# No database Tango context
+class TangoTestContext(object):
+    """ Context to run a device without a database."""
+
+    nodb = "#dbase=no"
+    command = "{0} {1} -ORBendPoint giop:tcp::{2} -file={3}"
+    connect_time = 6.0
+
+    def __init__(self, device, device_cls=None, server_name=None,
+                 instance_name=None, device_name=None, properties={},
+                 db="tango.db", port=0, debug=0, daemon=False, process=True):
+        """Inititalize the context to run a given device."""
+        # Argument
+        tangoclass = device.__name__
+        if not server_name:
+            server_name = tangoclass
+        if not instance_name:
+            instance_name = server_name.lower()
+        if not device_name:
+            device_name = 'test/nodb/' + server_name.lower()
+        if not port:
+            port = get_port()
+        # Attributes
+        self.port = port
+        self.device_name = device_name
+        self.server_name = "/".join(("dserver", server_name, instance_name))
+        self.host = "{0}:{1}/".format(platform.node(), self.port)
+        self.device = self.server = None
+        # File
+        self.generate_db_file(server_name, instance_name, device_name,
+                              tangoclass, properties, db)
+        # Command args
+        string = self.command.format(server_name, instance_name, port, db)
+        string += " -v{0}".format(debug) if debug else ""
+        cmd_args = string.split()
+        # Target and arguments
+        if device_cls:
+            target = run
+            args = ({tangoclass: (device_cls, device)}, cmd_args)
+        elif not hasattr(device, 'run_server'):
+            target = run
+            args = ((device,), cmd_args)
+        else:
+            target = device.run_server
+            args = (cmd_args,)
+        # Thread
+        cls = Process if process else Thread
+        self.thread = cls(target=target, args=args)
+        self.thread.daemon = daemon
+
+    @staticmethod
+    def generate_db_file(server, instance, device,
+                         tangoclass=None, properties={}, db="tango.db"):
+        """Generate a database file corresponding to the given arguments."""
+        if not tangoclass:
+            tangoclass = server
+        # Open the file
+        with open(db, 'w') as f:
+            f.write("/".join((server, instance, "DEVICE", tangoclass)))
+            f.write(': "' + device + '"\n')
+        # Create database
+        db = Database(db)
+        # Patched the property dict to avoid a PyTango bug
+        patched = dict((key, value if value != '' else ' ')
+                       for key, value in properties.items())
+        # Write properties
+        db.put_device_property(device, patched)
+        return db
+
+    def get_device_access(self):
+        """Return the full device name."""
+        return self.host+self.device_name+self.nodb
+
+    def get_server_access(self):
+        """Return the full server name."""
+        return self.host+self.server_name+self.nodb
+
+    def start(self):
+        """Run the server."""
+        self.thread.start()
+        self.connect()
+        return self
+
+    @retry(connect_time, [ConnectionFailed, DevFailed])
+    def connect(self):
+        self.device = DeviceProxy(self.get_device_access())
+        self.device.ping()
+        self.server = DeviceProxy(self.get_server_access())
+        self.server.ping()
+
+    def stop(self, timeout=None):
+        """Kill the server."""
+        if self.server:
+            self.server.command_inout('Kill')
+        self.thread.join(timeout)
+
+    def join(self, timeout=None):
+        self.thread.join(timeout)
+
+    def __enter__(self):
+        """Enter method for context support."""
+        if not self.thread.is_alive():
+            self.start()
+        return self.device
+
+    def __exit__(self, exc_type, exception, trace):
+        """Exit method for context support."""
+        self.stop()

--- a/test/context.py
+++ b/test/context.py
@@ -27,7 +27,8 @@ def retry(period, errors, pause=0.001):
                 sleep(pause)
                 try:
                     return func(*args, **kwargs)
-                except errors as e:
+                except errors as exc:
+                    e = exc
                     first = False
             raise e
         return wrapper

--- a/test/context.py
+++ b/test/context.py
@@ -78,7 +78,7 @@ class TangoTestContext(object):
         self.host = "{0}:{1}/".format(platform.node(), self.port)
         self.device = self.server = None
         # File
-        self.generate_db_file(server_name, instance_name, device_name, db,
+        self.generate_db_file(server_name, instance_name, device_name,
                               tangoclass, properties)
         # Command args
         string = self.command.format(server_name, instance_name, port, db)
@@ -99,18 +99,17 @@ class TangoTestContext(object):
         self.thread = cls(target=target, args=args)
         self.thread.daemon = daemon
 
-    @staticmethod
-    def generate_db_file(server, instance, device, db,
+    def generate_db_file(self, server, instance, device,
                          tangoclass=None, properties={}):
         """Generate a database file corresponding to the given arguments."""
         if not tangoclass:
             tangoclass = server
         # Open the file
-        with open(db, 'w') as f:
+        with open(self.db, 'w') as f:
             f.write("/".join((server, instance, "DEVICE", tangoclass)))
             f.write(': "' + device + '"\n')
         # Create database
-        db = Database(db)
+        db = Database(self.db)
         # Patched the property dict to avoid a PyTango bug
         patched = dict((key, value if value != '' else ' ')
                        for key, value in properties.items())

--- a/test/context.py
+++ b/test/context.py
@@ -1,6 +1,7 @@
 """Contain the context to run a device without a database."""
 
 # Imports
+import os
 import platform
 import tempfile
 from socket import socket
@@ -70,6 +71,7 @@ class TangoTestContext(object):
         if db is None:
             _, db = tempfile.mkstemp()
         # Attributes
+        self.db = db
         self.port = port
         self.device_name = device_name
         self.server_name = "/".join(("dserver", server_name, instance_name))
@@ -142,6 +144,7 @@ class TangoTestContext(object):
         if self.server:
             self.server.command_inout('Kill')
         self.thread.join(timeout)
+        os.unlink(self.db)
 
     def join(self, timeout=None):
         self.thread.join(timeout)

--- a/test/context.py
+++ b/test/context.py
@@ -54,7 +54,7 @@ class TangoTestContext(object):
 
     def __init__(self, device, device_cls=None, server_name=None,
                  instance_name=None, device_name=None, properties={},
-                 db="tango.db", port=0, debug=0, daemon=False, process=True):
+                 db="tango.db", port=0, debug=0, daemon=False, process=False):
         """Inititalize the context to run a given device."""
         # Argument
         tangoclass = device.__name__

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 from six import add_metaclass
 
 from tango import DevState
 from tango.server import Device, DeviceMeta
 
 from context import TangoTestContext
+
+
+@pytest.fixture(params=DevState.names.values())
+def state(request):
+    return request.param
 
 
 def test_empty_device():
@@ -19,16 +25,17 @@ def test_empty_device():
         assert proxy.status() == 'The device is in UNKNOWN state.'
 
 
-def test_set_state():
+def test_set_state(state):
+    status = 'The device is in {0!s} state.'.format(state)
 
     @add_metaclass(DeviceMeta)
     class TestDevice(Device):
         def init_device(self):
-            self.set_state(DevState.ON)
+            self.set_state(state)
 
     with TangoTestContext(TestDevice) as proxy:
-        assert proxy.state() == DevState.ON
-        assert proxy.status() == 'The device is in ON state.'
+        assert proxy.state() == state
+        assert proxy.status() == status
 
 
 def test_set_status():

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -12,7 +12,7 @@ from context import TangoTestContext
 
 # Fixtures
 
-@pytest.fixture(params=DevState.names.values())
+@pytest.fixture(params=DevState.values.values())
 def state(request):
     return request.param
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from tango import DevState
+from tango.server import Device, DeviceMeta
+
+from context import TangoTestContext
+
+
+def test_empty_device():
+
+    class TestDevice(Device):
+        __metaclass__ = DeviceMeta
+
+    with TangoTestContext(TestDevice) as proxy:
+        assert proxy.state() == DevState.UNKNOWN
+        assert proxy.status() == 'The device is in UNKNOWN state.'
+
+
+def test_set_state():
+
+    class TestDevice(Device):
+        __metaclass__ = DeviceMeta
+
+        def init_device(self):
+            print('hey')
+            self.set_state(DevState.ON)
+
+    with TangoTestContext(TestDevice) as proxy:
+        assert proxy.state() == DevState.ON
+        assert proxy.status() == 'The device is in ON state.'
+
+
+def test_set_status():
+
+    status = '\n'.join((
+        "This is a multiline status",
+        "with special characters such as",
+        "Café à la crème"))
+
+    class TestDevice(Device):
+        __metaclass__ = DeviceMeta
+
+        def init_device(self):
+            self.set_state(DevState.ON)
+            self.set_status(status)
+
+    with TangoTestContext(TestDevice) as proxy:
+        assert proxy.state() == DevState.ON
+        assert proxy.status() == status

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from six import add_metaclass
+
 from tango import DevState
 from tango.server import Device, DeviceMeta
 
@@ -8,8 +10,9 @@ from context import TangoTestContext
 
 def test_empty_device():
 
+    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
-        __metaclass__ = DeviceMeta
+        pass
 
     with TangoTestContext(TestDevice) as proxy:
         assert proxy.state() == DevState.UNKNOWN
@@ -18,11 +21,9 @@ def test_empty_device():
 
 def test_set_state():
 
+    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
-        __metaclass__ = DeviceMeta
-
         def init_device(self):
-            print('hey')
             self.set_state(DevState.ON)
 
     with TangoTestContext(TestDevice) as proxy:
@@ -37,9 +38,8 @@ def test_set_status():
         "with special characters such as",
         "Café à la crème"))
 
+    @add_metaclass(DeviceMeta)
     class TestDevice(Device):
-        __metaclass__ = DeviceMeta
-
         def init_device(self):
             self.set_state(DevState.ON)
             self.set_status(status)


### PR DESCRIPTION
This PR is meant to be a discussion about unit-testing pytango.

As a starting point, 3 tests have already been implemented: `test_empty_device`, `test_set_state` and `test_set_status`. Running pytest gives the following result (works with python 2 and python 3):

```console
.../pytango $ pytest -v
================================================ test session starts ================================================
platform linux2 -- Python 2.7.6, pytest-3.0.3, py-1.4.31, pluggy-0.4.0 -- ~/.virtualenvs/tango9/bin/python
cachedir: .cache
rootdir: /home/vinmic/pytango, inifile: 
collected 3 items 

test/test_server.py::test_empty_device PASSED
test/test_server.py::test_set_state PASSED
test/test_server.py::test_set_status PASSED

============================================= 3 passed in 10.20 seconds =============================================
```

As you can see the tests are really slow. It turns out the first test lasts a few milliseconds whereas the following tests last 5 seconds. After investigation, I realized the device server takes exactly 5 seconds to start for the last two tests. Does anyone have an explanation for that?