### PR TITLE
Better port affectation in the test context

### DIFF
--- a/tango/server.py
+++ b/tango/server.py
@@ -26,7 +26,6 @@ import types
 import inspect
 import logging
 import weakref
-import operator
 import functools
 import traceback
 
@@ -1296,14 +1295,14 @@ def __to_cb(post_init_callback):
 
     err_msg = "post_init_callback must be a callable or " \
               "sequence <callable [, args, [, kwargs]]>"
-    if operator.isCallable(post_init_callback):
+    if callable(post_init_callback):
         f = post_init_callback
     elif is_non_str_seq(post_init_callback):
         length = len(post_init_callback)
         if length < 1 or length > 3:
             raise TypeError(err_msg)
         cb = post_init_callback[0]
-        if not operator.isCallable(cb):
+        if not callable(cb):
             raise TypeError(err_msg)
         args, kwargs = [], {}
         if length > 1:


### PR DESCRIPTION
Fix issue #73.  The test context now gets the server port by decoding the ds IOR in the `post_init_callback`.

It also gets rid of the `process` optional arguments, since the `post_init_callback` needs to set the port attribute on the context. This could be done using a queue instead, in order to allow the server to run in a different process. 